### PR TITLE
Sample points directly from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Total number of observation for species
 - Short wiki summary for species
 - Added tooltip for help and cycle image buttons
+- Functionality, button, to download a csv annotations on screen for the species, it will sample as described in the poster
 
 ### Updated
 - package-lock.json: Lock file was updated when ran with `npm i`, removal of testing libraries for react suggest a change in react's dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Total number of observation for species
 - Short wiki summary for species
 - Added tooltip for help and cycle image buttons
-- Functionality, button, to download a csv annotations on screen for the species, it will sample as described in the poster
+- Added a button to sample data-points from the annotation on-screen. Sampling is handled in backend with a uniform sampling in a circle that encapsulates the hexagon. Downloaded csv is directly compatible with fine-tuning suite on SINR.
 
 ### Updated
 - package-lock.json: Lock file was updated when ran with `npm i`, removal of testing libraries for react suggest a change in react's dependencies.

--- a/src/backend/app/data_extraction.py
+++ b/src/backend/app/data_extraction.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import h3
+import shapely
+import pyproj
+import numpy as np
+
+from . import tools
+
+PARAMS = {"sampling_mode": "circle", "max_amount": 7}  # polygon | circle
+
+
+def sample_points(taxa_name, annotation_hexagons, hex_resolution, params=PARAMS):
+    taxon_id = tools.get_taxa_id_by_name(taxa_name)
+    hex_index = []
+    hex_type = []
+    presence_hexes = annotation_hexagons["presence"]
+    absence_hexes = annotation_hexagons["absence"]
+
+    psuedo_points = []
+    # enumerate lists by type, if more types are added consider using a dict and one-hot encoding
+    for hex_type, hexes in enumerate([absence_hexes, presence_hexes]):
+        for hex_id in hexes:
+            # sample psuedo-points for each hex
+            hex_boundary = h3.h3_to_geo_boundary(hex_id, geo_json=False)
+            random_n_points = None
+            N = max(params["max_amount"] - hex_resolution, 0) + 1
+            if params["sampling_mode"] == "polygon":
+                random_n_points = generate_random_points_in_polygon(hex_boundary, N)
+            else:
+                lat, lng = h3.h3_to_geo(hex_id)
+                random_n_points = generate_random_points_in_circle(
+                    lat, lng, hex_resolution, N
+                )
+
+            for random_lat, random_lng in random_n_points:
+                psuedo_points.append(
+                    {
+                        "taxon_id": taxon_id,
+                        "hex_type": hex_type,
+                        "latitude": random_lat,
+                        "longitude": random_lng,
+                    }
+                )
+    return pd.DataFrame(psuedo_points)
+
+
+def calculate_geo_distance(loc1, loc2):
+    lat1, lng1 = loc1
+    lat2, lng2 = loc2
+
+    geod = pyproj.Geod(ellps="WGS84")
+    _, _, distance = geod.inv(lons1=lng1, lats1=lat1, lons2=lng2, lats2=lat2)
+    return distance
+
+
+def generate_random_points_in_polygon(boundary, N):
+    polygon = shapely.Polygon(boundary)
+    min_alt, min_lng, max_alt, max_lng = polygon.bounds
+
+    random_points = []
+    while len(random_points) < N:
+        alt = np.random.uniform(min_alt, max_alt)
+        lng = np.random.uniform(min_lng, max_lng)
+
+        point = shapely.Point(alt, lng)
+        if polygon.contains(point):
+            random_points.append((alt, lng))
+
+    return random_points
+
+
+def generate_random_points_in_circle(lat, lng, R, N):
+    random_points = []
+    while len(random_points) < N:
+        r = R * np.sqrt(np.random.uniform(0, 1))  # random distance from center
+        theta = np.random.uniform(0, 2 * np.pi)  # random degree
+
+        # 111320m distance between longitudes and latitudes at the equator
+        x = lng + r * np.cos(theta) / (
+            111320 * np.cos(lat * np.pi / 180)
+        )  # r * np.cos(theta) / / (111320 * np.cos(lat * np.pi / 180)) finds the random point in x axis, division adjusts for length in the poles
+        y = lat + r * np.sin(theta) / 111320
+
+        random_points.append((y, x))
+
+    return random_points

--- a/src/backend/app/data_extraction.py
+++ b/src/backend/app/data_extraction.py
@@ -11,7 +11,6 @@ PARAMS = {"sampling_mode": "circle", "max_amount": 7}  # polygon | circle
 
 def sample_points(taxa_name, annotation_hexagons, hex_resolution, params=PARAMS):
     taxon_id = tools.get_taxa_id_by_name(taxa_name)
-    hex_index = []
     hex_type = []
     presence_hexes = annotation_hexagons["presence"]
     absence_hexes = annotation_hexagons["absence"]

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -153,8 +153,6 @@ async def sample_annotation(request: Request):
         taxa_name, annotation_hexagon_ids, hex_resolution
     )
 
-    # date_now = str(datetime.now())
-
     return StreamingResponse(
         iter([points_df.to_csv(index=False)]),
         media_type="text/csv",

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -156,7 +156,7 @@ async def sample_annotation(request: Request):
     return StreamingResponse(
         iter([points_df.to_csv(index=False)]),
         media_type="text/csv",
-        headers={"Content-Disposition": f"attachment; filename=annotation.csv"},
+        headers={"Content-Disposition": "attachment; filename=annotation.csv"},
     )
 
 

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -8,3 +8,5 @@ uvicorn==0.30.1
 alphashape==1.3.1
 sqlalchemy
 psycopg2-binary
+pyproj
+shapely

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -22,7 +22,7 @@ import {
   handleGeneratePrediction,
   handleLoadAnnotation,
   handleSaveAnnotation,
-  handleDownloadAnnotation,
+  handleSampleAnnotation,
 } from "./util"; // handler functions to be passed into components
 
 const OCEAN_MASK = false;
@@ -155,14 +155,14 @@ function App() {
                   handleLoadAnnotation(payloadData, handler);
                 }}
                 onClearAnnotation={() => handleClearAnnotation(null, handler)}
-                onDownloadAnnotation={() => {
+                onSampleAnnotation={() => {
                   const payloadData = {
                     taxa_name: sideBarData.taxa,
                     hex_resolution: sideBarData.hexResolution,
                     annotation_hexagon_ids: annotationHexagonIDs,
                   };
 
-                  handleDownloadAnnotation(payloadData, handler);
+                  handleSampleAnnotation(payloadData, handler);
                 }}
               />
               <LoadingOverlay

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -156,7 +156,6 @@ function App() {
                 }}
                 onClearAnnotation={() => handleClearAnnotation(null, handler)}
                 onDownloadAnnotation={() => {
-                  console.log("Downloading samples");
                   const payloadData = {
                     taxa_name: sideBarData.taxa,
                     hex_resolution: sideBarData.hexResolution,

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -22,6 +22,7 @@ import {
   handleGeneratePrediction,
   handleLoadAnnotation,
   handleSaveAnnotation,
+  handleDownloadAnnotation,
 } from "./util"; // handler functions to be passed into components
 
 const OCEAN_MASK = false;
@@ -154,6 +155,16 @@ function App() {
                   handleLoadAnnotation(payloadData, handler);
                 }}
                 onClearAnnotation={() => handleClearAnnotation(null, handler)}
+                onDownloadAnnotation={() => {
+                  console.log("Downloading samples");
+                  const payloadData = {
+                    taxa_name: sideBarData.taxa,
+                    hex_resolution: sideBarData.hexResolution,
+                    annotation_hexagon_ids: annotationHexagonIDs,
+                  };
+
+                  handleDownloadAnnotation(payloadData, handler);
+                }}
               />
               <LoadingOverlay
                 visible={isLoading}

--- a/src/frontend/src/api.js
+++ b/src/frontend/src/api.js
@@ -35,6 +35,11 @@ export async function saveAnnotation(data) {
   return await response.json();
 }
 
+/**
+ * API request function that gets a "stream" response that represents a file
+ * @param {JSON} data
+ * @returns {Blob}
+ */
 export async function downloadAnnotation(data) {
   const response = await fetch(`${API_URL}/sample_annotation/`, {
     method: "POST",

--- a/src/frontend/src/api.js
+++ b/src/frontend/src/api.js
@@ -40,7 +40,7 @@ export async function saveAnnotation(data) {
  * @param {JSON} data
  * @returns {Blob}
  */
-export async function downloadAnnotation(data) {
+export async function sampleAnnotation(data) {
   const response = await fetch(`${API_URL}/sample_annotation/`, {
     method: "POST",
     headers: {

--- a/src/frontend/src/api.js
+++ b/src/frontend/src/api.js
@@ -35,6 +35,22 @@ export async function saveAnnotation(data) {
   return await response.json();
 }
 
+export async function downloadAnnotation(data) {
+  const response = await fetch(`${API_URL}/sample_annotation/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error("Fetch error, status:", response.status);
+  }
+
+  return await response.blob();
+}
+
 export async function loadAnnotation(data) {
   const response = await fetch(`${API_URL}/load_annotation/`, {
     method: "POST",

--- a/src/frontend/src/components/Buttons.jsx
+++ b/src/frontend/src/components/Buttons.jsx
@@ -9,7 +9,7 @@ function ButtonsPanel({
   onClearAnnotation,
   onLoadAnnotation,
   onSwitchChange,
-  onDownloadAnnotation,
+  onSampleAnnotation,
   isValidTaxa,
 }) {
   // Buttons component, gets passed in logic handlers that manage state of the app
@@ -35,9 +35,9 @@ function ButtonsPanel({
       onClick: onClearAnnotation,
     },
     {
-      id: "download_annotation",
-      text: "Download Annotation",
-      onClick: onDownloadAnnotation,
+      id: "sample_annotation",
+      text: "Sample Annotation",
+      onClick: onSampleAnnotation,
     },
   ];
 

--- a/src/frontend/src/components/Buttons.jsx
+++ b/src/frontend/src/components/Buttons.jsx
@@ -9,6 +9,7 @@ function ButtonsPanel({
   onClearAnnotation,
   onLoadAnnotation,
   onSwitchChange,
+  onDownloadAnnotation,
   isValidTaxa,
 }) {
   // Buttons component, gets passed in logic handlers that manage state of the app
@@ -32,6 +33,11 @@ function ButtonsPanel({
       id: "clear_annotation",
       text: "Clear Annotation",
       onClick: onClearAnnotation,
+    },
+    {
+      id: "download_annotation",
+      text: "Download Annotation",
+      onClick: onDownloadAnnotation,
     },
   ];
 

--- a/src/frontend/src/components/Instruction.jsx
+++ b/src/frontend/src/components/Instruction.jsx
@@ -117,6 +117,17 @@ function Instruction() {
                   using the <b>Save Annotation</b> button.
                 </p>
               </li>
+              <li>
+                <strong className="download-annotation">
+                  Download Annotation
+                </strong>
+                : Clicking this button download the current annotation layers
+                into a csv file. You do not have to save the annotation, you can
+                download the annotations on screen for the selected species any
+                time. The file will have the species name and a timestamp as its
+                name.
+              </li>
+              <br />
             </ol>
 
             <h4>Drawing Tool Functionality:</h4>

--- a/src/frontend/src/components/Instruction.jsx
+++ b/src/frontend/src/components/Instruction.jsx
@@ -118,14 +118,12 @@ function Instruction() {
                 </p>
               </li>
               <li>
-                <strong className="download-annotation">
-                  Download Annotation
-                </strong>
-                : Clicking this button download the current annotation layers
-                into a csv file. You do not have to save the annotation, you can
-                download the annotations on screen for the selected species any
-                time. The file will have the species name and a timestamp as its
-                name.
+                <strong className="sample-annotation">Sample Annotation</strong>
+                : Click this button to download uniformly sampled points from
+                the current annotation layers into a csv file. You do not have
+                to save the annotation, you can download samples from the
+                annotations on screen for the selected species any time. The
+                file will have the species name and a timestamp as its name.
               </li>
               <br />
             </ol>

--- a/src/frontend/src/styles/Buttons.css
+++ b/src/frontend/src/styles/Buttons.css
@@ -42,6 +42,6 @@ button:disabled {
   background-color: #e14b23;
 }
 
-#download_annotation {
+#sample_annotation {
   background-color: steelblue;
 }

--- a/src/frontend/src/styles/Buttons.css
+++ b/src/frontend/src/styles/Buttons.css
@@ -41,3 +41,7 @@ button:disabled {
 #clear_annotation {
   background-color: #e14b23;
 }
+
+#download_annotation {
+  background-color: steelblue;
+}

--- a/src/frontend/src/styles/Instruction.css
+++ b/src/frontend/src/styles/Instruction.css
@@ -39,7 +39,7 @@
   border: none;
 }
 
-.download-annotation {
+.sample-annotation {
   padding: 0.1em 0.1em;
   background-color: steelblue;
   color: white;

--- a/src/frontend/src/styles/Instruction.css
+++ b/src/frontend/src/styles/Instruction.css
@@ -38,3 +38,10 @@
   color: white;
   border: none;
 }
+
+.download-annotation {
+  padding: 0.1em 0.1em;
+  background-color: steelblue;
+  color: white;
+  border: none;
+}

--- a/src/frontend/src/util.js
+++ b/src/frontend/src/util.js
@@ -1,5 +1,10 @@
 /* eslint-disable no-unused-vars */
-import { generatePrediction, saveAnnotation, loadAnnotation } from "./api"; // import necessary functions from api
+import {
+  generatePrediction,
+  saveAnnotation,
+  loadAnnotation,
+  downloadAnnotation,
+} from "./api"; // import necessary functions from api
 
 // parses taxa id from given string if it exists,
 export function parseTaxaID(taxaString) {
@@ -41,6 +46,27 @@ export async function handleSaveAnnotation(data, handler) {
     handler.loadingHandlers.close();
   } catch (error) {
     console.error("Error save annotation:", error);
+    alert("An unexpected error occurred.");
+  } finally {
+    handler.loadingHandlers.close();
+  }
+}
+
+export async function handleDownloadAnnotation(data, handler) {
+  try {
+    handler.loadingHandlers.open();
+    const blob = await downloadAnnotation(data);
+    const url = window.URL.createObjectURL(new Blob([blob]));
+    const link = document.createElement("a");
+    link.href = url;
+    const file_name = `${data.taxa_name}_${new Date().toString()}.csv`;
+    link.setAttribute("download", file_name);
+    document.body.appendChild(link);
+    link.click();
+    link.parentNode.removeChild(link);
+    handler.loadingHandlers.close();
+  } catch (error) {
+    console.log("Error downloading CSV:", error);
     alert("An unexpected error occurred.");
   } finally {
     handler.loadingHandlers.close();

--- a/src/frontend/src/util.js
+++ b/src/frontend/src/util.js
@@ -3,7 +3,7 @@ import {
   generatePrediction,
   saveAnnotation,
   loadAnnotation,
-  downloadAnnotation,
+  sampleAnnotation,
 } from "./api"; // import necessary functions from api
 
 // parses taxa id from given string if it exists,
@@ -57,10 +57,10 @@ export async function handleSaveAnnotation(data, handler) {
  * @param {JSON} data
  * @param {JSON} handler
  */
-export async function handleDownloadAnnotation(data, handler) {
+export async function handleSampleAnnotation(data, handler) {
   try {
     handler.loadingHandlers.open();
-    const blob = await downloadAnnotation(data);
+    const blob = await sampleAnnotation(data);
     // Downloading from UI has a strange workaround that creates a link for the file and must click to download
     // It won't render the link in UI, download is automatic
     const url = window.URL.createObjectURL(new Blob([blob]));
@@ -71,7 +71,6 @@ export async function handleDownloadAnnotation(data, handler) {
     document.body.appendChild(link);
     link.click();
     link.parentNode.removeChild(link);
-    handler.loadingHandlers.close();
   } catch (error) {
     console.log("Error downloading CSV:", error);
     alert("An unexpected error occurred.");

--- a/src/frontend/src/util.js
+++ b/src/frontend/src/util.js
@@ -52,10 +52,17 @@ export async function handleSaveAnnotation(data, handler) {
   }
 }
 
+/**
+ * Handles download annotation button click. Data is hexagons on screen and species metadata, handler is an object of functions to control UI and state changes.
+ * @param {JSON} data
+ * @param {JSON} handler
+ */
 export async function handleDownloadAnnotation(data, handler) {
   try {
     handler.loadingHandlers.open();
     const blob = await downloadAnnotation(data);
+    // Downloading from UI has a strange workaround that creates a link for the file and must click to download
+    // It won't render the link in UI, download is automatic
     const url = window.URL.createObjectURL(new Blob([blob]));
     const link = document.createElement("a");
     link.href = url;


### PR DESCRIPTION
## Added:
- Button to download a csv annotation distribution
- Server code to convert hexagons to csv points
- New server request route to download annotations

## Updated:
- changelog

How to test:
You can choose any species and start annotating.
Click download annotation to download a csv, you may need to allow some pop-up things on the browser if it asks for it.
Currently samples 4 points from each hexagon, but this can be changed in the backend, or we can add it as an input field in the frontend so user decides how much to sample.

closes #91 